### PR TITLE
Fit accepts position.

### DIFF
--- a/src/Operations.php
+++ b/src/Operations.php
@@ -71,7 +71,8 @@ class Operations
                 if ($preventUpscale) {
                     $constraint->upsize();
                 }
-            }
+            },
+            $arguments['position'] ?? 'center',
         );
     }
 


### PR DESCRIPTION
As per docblock

    @method \Intervention\Image\Image fit(int $width, int $height = null, \Closure $callback = null, string $position = 'center')      